### PR TITLE
README: add missing dependency to xorriso

### DIFF
--- a/README
+++ b/README
@@ -93,7 +93,7 @@ Build the CD image on the build machine:
 
 ## install prerequisites
 apt-get update
-apt-get install -y simple-cdd git
+apt-get install -y simple-cdd git xorriso
 
 ## get our latest files
 mkdir /opt/pcengines


### PR DESCRIPTION
Without xorriso installed, we get this error message:

rsc@leda:~/debian/pcengines-apu-debian-cd$ build-simple-cdd --conf profiles/apu64.conf --dist stretch
2017-07-31 23:24:12 ERROR build/debian-cd exited with code 2
2017-07-31 23:24:12 ERROR Last 5 lines of standard error:
2017-07-31 23:24:12 ERROR build/debian-cd: Can't exec "xorriso": No such file or directory at /home/rsc/debian/pcengines-apu-debian-cd/tmp/debian-cd/tools/make_disc_trees.pl line 95.
2017-07-31 23:24:12 ERROR build/debian-cd: Use of uninitialized value $mkisofs_version in concatenation (.) or string at /home/rsc/debian/pcengines-apu-debian-cd/tmp/debian-cd/tools/make_disc_trees.pl line 96.
2017-07-31 23:24:12 ERROR build/debian-cd: Use of uninitialized value $mkisofs_version in concatenation (.) or string at /home/rsc/debian/pcengines-apu-debian-cd/tmp/debian-cd/tools/make_disc_trees.pl line 97.
2017-07-31 23:24:12 ERROR build/debian-cd: Can't open Packages file /home/rsc/debian/pcengines-apu-debian-cd/tmp/cd-build/stretch/CD1/dists/stretch/main/binary-amd64/Packages : No such file or directory
2017-07-31 23:24:12 ERROR build/debian-cd: make: *** [image-trees] Error 2

Signed-off-by: Robert Schwebel <r.schwebel@pengutronix.de>